### PR TITLE
Changes to allow text to continue working when video source is turned off

### DIFF
--- a/field.py
+++ b/field.py
@@ -22,7 +22,7 @@ GPIO.setup(22, GPIO.IN)
 
 try:
   while True:
-    GPIO.wait_for_edge(22, GPIO.RISING) # Look for the field pulse
+    GPIO.wait_for_edge(22, GPIO.FALLING) # Look for the field pulse
     GPIO.output(4, GPIO.HIGH) # blink the LED
     GPIO.wait_for_edge(22, GPIO.FALLING) # Look for the field pulse
     GPIO.output(4, GPIO.LOW) # blink the LED

--- a/saa7113.py
+++ b/saa7113.py
@@ -15,7 +15,7 @@ def saa7113():
   bus.write_byte_data(0x25, 0x05, 0x00) # 0x05,0x00, // analog control 4 - Static Gain channel 2 (Don't care)
   bus.write_byte_data(0x25, 0x06, 0xe9) # 0x06,0xe9, // horiz sync start - e9 recommnded
   bus.write_byte_data(0x25, 0x07, 0x0d) # 0x07,0x0d, // horiz sync stop - 0d recommended
-  bus.write_byte_data(0x25, 0x08, 0x98) # 0x08,0x98, // sync control - vertical noise=normal, PLL closed, Fast locking mode, field toggle on interlace, field detection AUFD 
+  bus.write_byte_data(0x25, 0x08, 0x00) # 0x08,0x98, // sync control - vertical noise=normal, PLL closed, TV mode, field toggle on interlace, field selection fixed to 50Hz. TV mode used because fast locking mode can change to out-of-spec timings when removing video source, preventing text from working when source disconnected.
   bus.write_byte_data(0x25, 0x09, 0x01) # 0x09,0x01, // luminance control - aperture factor = 0.25, update agc per line,active luma (correct?), bandpass 4MHz, prefilter bypassed, chroma trap set for CVBS
   bus.write_byte_data(0x25, 0x0a, 0x80) # 0x0a,0x80, // luminance brightness - Set to ITU level
   bus.write_byte_data(0x25, 0x0b, 0x47) # 0x0b,0x47, // luminance contrast - Set to ITU level
@@ -25,7 +25,7 @@ def saa7113():
   bus.write_byte_data(0x25, 0x0f, 0x2a) # 0x0f,0x2a, // chrominance gain control ?
   bus.write_byte_data(0x25, 0x10, 0x01) # 0x10,0x00, // format/delay control - Mainly ITU 656
   bus.write_byte_data(0x25, 0x11, 0x0c) # 0x11,0x0c, // output control 1
-  bus.write_byte_data(0x25, 0x12, 0xa1) # 0x12,0xa1, // output control 2 - Default 0x01. Controls RTS0 (don't care) and RTS1 - ODD/EVEN Field
+  bus.write_byte_data(0x25, 0x12, 0xb1) # 0x12,0xa1, // output control 2 - Default 0x01. Controls RTS0 (don't care) and RTS1 - Vertical Sync
   bus.write_byte_data(0x25, 0x13, 0x00) # 0x13,0x00, // output control 3 - Analog test select (don't care)
 
   bus.write_byte_data(0x25, 0x15, 0x00) # 0x15,0x00, // VGATE start - Probably don't care

--- a/vbit.py
+++ b/vbit.py
@@ -99,7 +99,7 @@ try:
     
     # Sequence the startup so we get fully buffered before we start transmitting
     if countdown==1: # now the buffer is full we can enable interrupts
-      GPIO.add_event_detect(GPIO_FLD, GPIO.BOTH, callback=fieldEdge) # Look for the field pulse   
+      GPIO.add_event_detect(GPIO_FLD, GPIO.FALLING, callback=fieldEdge) # Look for the field pulse   
     if countdown>0:
       countdown-=1
 


### PR DESCRIPTION
The existing configuration generates an even/odd field signal from the SAA7113 which triggers the Pi to send data, This signal is not generated when the video source is disconnected so text will stop working, but the SAA7113 will continue to generate a blank video signal, so if the data triggering is done from vertical sync instead then text will continue working even with no video source.
Horizontal time constant selection changed from fast locking mode to TV mode
Programmable output connected to Pi changed from even/odd field to vertical sync
Corresponding trigger on Pi changed from both edges to falling edge